### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to set memory limit via `cesapp edit-config`
-- Optimized max heap size in limited dockerized environments (#27)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf` (#27)
 
 ## [v1.4.1-1] - 2020-10-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to set memory limit via `cesapp edit-config`
+- Optimized max heap size in limited dockerized environments (#27)
+
 ## [v1.4.1-1] - 2020-10-09
 ### Fixed
 - Fixed bug where no error was shown on invalid password policy or when the endpoint could not be reached

--- a/dogu.json
+++ b/dogu.json
@@ -47,6 +47,24 @@
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
       }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the Usermgt process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Usermgt: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Usermgt process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Usermgt: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
     }
   ],
   "ServiceAccounts": [

--- a/dogu.json
+++ b/dogu.json
@@ -31,6 +31,22 @@
       "Name": "password_policy",
       "Description": "Configure a password policy for users passwords, based on a set of rules",
       "Optional": true
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 200m of memory for usermgt.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description":"Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "ServiceAccounts": [

--- a/resources/opt/apache-tomcat/bin/setenv.sh
+++ b/resources/opt/apache-tomcat/bin/setenv.sh
@@ -5,3 +5,7 @@ JAVA_OPTS="$JAVA_OPTS -Duniverseadm.stage=PRODUCTION"
 JAVA_OPTS="$JAVA_OPTS -Duniverseadm.home=/var/lib/usermgt/conf"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=/etc/ssl/truststore.jks"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"
+if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
+  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=85.0"
+  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=50.0"
+fi

--- a/resources/opt/apache-tomcat/bin/setenv.sh
+++ b/resources/opt/apache-tomcat/bin/setenv.sh
@@ -6,6 +6,11 @@ JAVA_OPTS="$JAVA_OPTS -Duniverseadm.home=/var/lib/usermgt/conf"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=/etc/ssl/truststore.jks"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"
 if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
-  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=85.0"
-  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=50.0"
+  # Retrieve configurable java limits from etcd, valid default values exist
+  MEMORY_LIMIT_MAX_PERCENTAGE=$(doguctl config "container_config/java_max_ram_percentage")
+  MEMORY_LIMIT_MIN_PERCENTAGE=$(doguctl config "container_config/java_min_ram_percentage")
+
+  echo "Setting memory limits to MaxRAMPercentage: ${MEMORY_LIMIT_MAX_PERCENTAGE} and MinRAMPercentage: ${MEMORY_LIMIT_MIN_PERCENTAGE}..."
+  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}"
+  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE}"
 fi


### PR DESCRIPTION
Fixes #27 

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the Usermgt-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0