### PR TITLE
Show additional hints only to admins

### DIFF
--- a/app/src/main/ui/src/components/ProtectedResource.tsx
+++ b/app/src/main/ui/src/components/ProtectedResource.tsx
@@ -1,8 +1,8 @@
 import {H1} from '@cloudogu/deprecated-ces-theme-tailwind';
 import React, {useContext} from 'react';
 import {t} from '../helpers/i18nHelpers';
-import {ApplicationContext} from '../main';
 import TitledPage from './TitledPage';
+import { ApplicationContext } from './contexts/ApplicationContext';
 
 export default function ProtectedResource(props: {pageName: string, children: React.JSX.Element}){
     const {casUser} = useContext(ApplicationContext);

--- a/app/src/main/ui/src/components/contexts/ApplicationContext.tsx
+++ b/app/src/main/ui/src/components/contexts/ApplicationContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import type { CasUser } from "../../services/CasUser";
+
+export type ApplicationContextProps = {
+    casUser: CasUser;
+}
+export const ApplicationContext = createContext<ApplicationContextProps>({
+    casUser: {
+        principal: "default",
+        admin: false,
+        loading: true
+    },
+});
+
+export function useApplicationContext() {
+    const context = useContext(ApplicationContext);
+
+    if(!context){
+        throw new Error("no ApplicationContext provided for useApplicationContext");
+    }
+
+    return context;
+}

--- a/app/src/main/ui/src/components/groups/GroupForm.tsx
+++ b/app/src/main/ui/src/components/groups/GroupForm.tsx
@@ -1,6 +1,5 @@
 import {Button, Form, H2, ListWithSearchbar, useFormHandler} from "@cloudogu/deprecated-ces-theme-tailwind";
 import {TrashIcon} from "@heroicons/react/24/outline";
-import React from "react";
 import {useNavigate} from "react-router-dom";
 import {t} from "../../helpers/i18nHelpers";
 import {useBackURL} from "../../hooks/useBackURL";

--- a/app/src/main/ui/src/components/users/UserForm.tsx
+++ b/app/src/main/ui/src/components/users/UserForm.tsx
@@ -1,18 +1,18 @@
-import {deprecated_Form as Form, Details} from "@cloudogu/ces-theme-tailwind";
-import {Button, H2, ListWithSearchbar} from "@cloudogu/deprecated-ces-theme-tailwind";
-import {TrashIcon} from "@heroicons/react/24/outline";
-import React from "react";
-import {twMerge} from "tailwind-merge";
-import {t} from "../../helpers/i18nHelpers";
-import {useConfirmation} from "../../hooks/useConfirmation";
-import {Prompt} from "../../hooks/usePrompt";
+import { deprecated_Form as Form, Details } from "@cloudogu/ces-theme-tailwind";
+import { Button, H2, ListWithSearchbar } from "@cloudogu/deprecated-ces-theme-tailwind";
+import { TrashIcon } from "@heroicons/react/24/outline";
+import { twMerge } from "tailwind-merge";
+import { t } from "../../helpers/i18nHelpers";
+import { useConfirmation } from "../../hooks/useConfirmation";
+import { Prompt } from "../../hooks/usePrompt";
 import useUserFormHandler from "../../hooks/useUserFormHandler";
-import {GroupsService} from "../../services/Groups";
-import {ConfirmationDialog} from "../ConfirmationDialog";
+import { GroupsService } from "../../services/Groups";
+import { ConfirmationDialog } from "../ConfirmationDialog";
+import { useApplicationContext } from "../contexts/ApplicationContext";
 import HelpLink from "../helpLink";
-import type {Group} from "../../services/Groups";
-import type {User} from "../../services/Users";
-import type {NotifyFunction, UseFormHandlerFunctions} from "@cloudogu/deprecated-ces-theme-tailwind";
+import type { Group } from "../../services/Groups";
+import type { User } from "../../services/Users";
+import type { NotifyFunction, UseFormHandlerFunctions } from "@cloudogu/deprecated-ces-theme-tailwind";
 
 const MAX_SEARCH_RESULTS = 10;
 
@@ -29,17 +29,15 @@ export interface UserFormProps<T extends User> {
 }
 
 export default function UserForm<T extends User>(props: UserFormProps<T>) {
-    const {
-        handler,
-        notification,
-        notify
-    } = useUserFormHandler<T>(props.initialUser, (values: T) => props.onSubmit(values, notify, handler));
-    const {open, setOpen: toggleModal, targetName: groupName, setTargetName: setGroupName} = useConfirmation();
+    const { handler, notification, notify } = useUserFormHandler<T>(props.initialUser, (values: T) => props.onSubmit(values, notify, handler));
+    const { open, setOpen: toggleModal, targetName: groupName, setTargetName: setGroupName } = useConfirmation();
+
+    const { admin } = useApplicationContext().casUser;
 
     const addGroup = (groupName: string): void => {
         if (handler.values.memberOf.indexOf(groupName) < 0) {
             const newGroups = [...handler.values.memberOf, groupName];
-            handler.setValues({...handler.values, memberOf: newGroups});
+            handler.setValues({ ...handler.values, memberOf: newGroups });
         }
     };
 
@@ -59,15 +57,12 @@ export default function UserForm<T extends User>(props: UserFormProps<T>) {
     };
 
     const queryGroups = async (searchValue: string): Promise<string[]> => {
-        const groupsData = await GroupsService.query(
-            undefined,
-            {
-                page: 1,
-                page_size: MAX_SEARCH_RESULTS,
-                query: searchValue,
-                exclude: handler.values.memberOf ?? [],
-            }
-        );
+        const groupsData = await GroupsService.query(undefined, {
+            page: 1,
+            page_size: MAX_SEARCH_RESULTS,
+            query: searchValue,
+            exclude: handler.values.memberOf ?? [],
+        });
         return groupsData.data.map((x: Group) => x.name);
     };
 
@@ -83,100 +78,109 @@ export default function UserForm<T extends User>(props: UserFormProps<T>) {
             addLable={t("users.labels.addGroup")}
             removeLable={t("users.labels.removeGroup")}
             emptyItemsLable={t("users.labels.emptyGroups")}
-            removeIcon={<TrashIcon className={"w-6 h-6"}/>}
+            removeIcon={<TrashIcon className={"w-6 h-6"} />}
             pageSize={pageSize}
-        />);
+        />
+    );
 
-    return <>
-        <ConfirmationDialog
-            open={open ?? false}
-            data-testid="remove-group-dialog"
-            onClose={() => toggleModal(false)}
-            onConfirm={async () => {
-                await removeGroup(groupName ?? "");
-            }}
-            title={t("users.labels.removeGroup")}
-            message={t("users.labels.removeGroupConfirmationMessage", {groupName: groupName})}/>
-        <Prompt when={handler.dirty && !handler.isSubmitting} message={t("generic.notification.form.prompt")}/>
-        <Form handler={handler}>
-            {notification}
-            <Form.ValidatedTextInput type={"text"} name={"username"} disabled={props.disableUsernameField ?? true}
-                data-testid="username" placeholder={t("users.placeholder.username")}
-                hint={t("users.hint.username")}>
-                {t("editUser.labels.username")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"text"} name={"givenname"} data-testid="givenname"
-                placeholder={t("users.placeholder.givenname")}>
-                {t("editUser.labels.givenName")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"text"} name={"surname"} data-testid="surname"
-                placeholder={t("users.placeholder.surname")}>
-                {t("editUser.labels.surname")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"text"} name={"displayName"} data-testid="displayName"
-                placeholder={t("users.placeholder.displayName")} hint={t("users.hint.displayName")}>
-                {t("editUser.labels.displayName")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"text"} name={"mail"} data-testid="mail"
-                placeholder={t("users.placeholder.mail")}>
-                {t("editUser.labels.email")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"password"} name={"password"} data-testid="password"
-                placeholder={t("users.placeholder.password")}>
-                {t("editUser.labels.password")}
-            </Form.ValidatedTextInput>
-            <Form.ValidatedTextInput type={"password"} name={"confirmPassword"} data-testid="confirmPassword"
-                placeholder={t("users.placeholder.confirmPassword")}>
-                {t("editUser.labels.confirmPassword")}
-            </Form.ValidatedTextInput>
+    return (
+        <>
+            <ConfirmationDialog
+                open={open ?? false}
+                data-testid="remove-group-dialog"
+                onClose={() => toggleModal(false)}
+                onConfirm={async () => {
+                    await removeGroup(groupName ?? "");
+                }}
+                title={t("users.labels.removeGroup")}
+                message={t("users.labels.removeGroupConfirmationMessage", { groupName: groupName })}
+            />
+            <Prompt when={handler.dirty && !handler.isSubmitting} message={t("generic.notification.form.prompt")} />
+            <Form handler={handler}>
+                {notification}
+                <Form.ValidatedTextInput type={"text"} name={"username"} disabled={props.disableUsernameField ?? true} data-testid="username" placeholder={t("users.placeholder.username")} hint={t("users.hint.username")}>
+                    {t("editUser.labels.username")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"text"} name={"givenname"} data-testid="givenname" placeholder={t("users.placeholder.givenname")}>
+                    {t("editUser.labels.givenName")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"text"} name={"surname"} data-testid="surname" placeholder={t("users.placeholder.surname")}>
+                    {t("editUser.labels.surname")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"text"} name={"displayName"} data-testid="displayName" placeholder={t("users.placeholder.displayName")} hint={t("users.hint.displayName")}>
+                    {t("editUser.labels.displayName")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"text"} name={"mail"} data-testid="mail" placeholder={t("users.placeholder.mail")}>
+                    {t("editUser.labels.email")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"password"} name={"password"} data-testid="password" placeholder={t("users.placeholder.password")}>
+                    {t("editUser.labels.password")}
+                </Form.ValidatedTextInput>
+                <Form.ValidatedTextInput type={"password"} name={"confirmPassword"} data-testid="confirmPassword" placeholder={t("users.placeholder.confirmPassword")}>
+                    {t("editUser.labels.confirmPassword")}
+                </Form.ValidatedTextInput>
 
-            <>
-                {props.passwordReset &&
-                    <>
-                        <Form.ValidatedCheckboxLabelRight name={"pwdReset"} data-testid="pwdReset">
-                            {t("editUser.labels.mustChangePassword")}
-                        </Form.ValidatedCheckboxLabelRight>
-                        <div className={"invisible"}>
-                            <Form.ValidatedCheckboxLabelRight name={"external"} data-testid="external">
-                                {t("editUser.labels.external")}
-                            </Form.ValidatedCheckboxLabelRight>
-                        </div>
-                    </>
-                }
-            </>
-
-            {props.groupsReadonly ? <></> :
                 <>
-                    <H2>{t("users.labels.groups")} ({handler.values.memberOf.length})</H2>
-                    {renderGroupsList()}
+                    {props.passwordReset && (
+                        <>
+                            <Form.ValidatedCheckboxLabelRight name={"pwdReset"} data-testid="pwdReset">
+                                {t("editUser.labels.mustChangePassword")}
+                            </Form.ValidatedCheckboxLabelRight>
+                            <div className={"invisible"}>
+                                <Form.ValidatedCheckboxLabelRight name={"external"} data-testid="external">
+                                    {t("editUser.labels.external")}
+                                </Form.ValidatedCheckboxLabelRight>
+                            </div>
+                        </>
+                    )}
                 </>
-            }
 
-            <div className={"my-4"}>
-                <Button variant={"primary"} type={"submit"} disabled={!handler.dirty} data-testid="save-button">
-                    {t("editUser.buttons.save")}
-                </Button>
-                {props.additionalButtons as JSX.Element}
-            </div>
-        </Form>
+                {props.groupsReadonly ? (
+                    <></>
+                ) : (
+                    <>
+                        <H2>
+                            {t("users.labels.groups")} ({handler.values.memberOf.length})
+                        </H2>
+                        {renderGroupsList()}
+                    </>
+                )}
 
-        {props.groupsReadonly ?
-            <>
-                <H2>{t("users.labels.myGroups")} ({handler.values.memberOf.length})</H2>
-                {renderGroupsList(true, 10)}
-            </>
-            : <></>
-        }
-        <hr/>
-        <Details className={twMerge("py-2")}>
-            <Details.Summary>
-                <Details.Summary.Arrow/>
-                {t("users.steps.title")}
-            </Details.Summary>
-            <Details.Content>
-                {t("users.steps.text")}
-                <HelpLink/>
-            </Details.Content>
-        </Details>
-    </>;
+                <div className={"my-4"}>
+                    <Button variant={"primary"} type={"submit"} disabled={!handler.dirty} data-testid="save-button">
+                        {t("editUser.buttons.save")}
+                    </Button>
+                    {props.additionalButtons as JSX.Element}
+                </div>
+            </Form>
+
+            {props.groupsReadonly ? (
+                <>
+                    <H2>
+                        {t("users.labels.myGroups")} ({handler.values.memberOf.length})
+                    </H2>
+                    {renderGroupsList(true, 10)}
+                </>
+            ) : (
+                <></>
+            )}
+            {admin ? (
+                <>
+                    <hr />
+                    <Details className={twMerge("py-2")}>
+                        <Details.Summary>
+                            <Details.Summary.Arrow />
+                            {t("users.steps.title")}
+                        </Details.Summary>
+                        <Details.Content>
+                            {t("users.steps.text")}
+                            <HelpLink />
+                        </Details.Content>
+                    </Details>
+                </>
+            ) : (
+                <></>
+            )}
+        </>
+    );
 }

--- a/app/src/main/ui/src/main.tsx
+++ b/app/src/main/ui/src/main.tsx
@@ -1,5 +1,5 @@
 import {Main, Navbar} from "@cloudogu/deprecated-ces-theme-tailwind";
-import React, {createContext, useContext} from "react";
+import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import {useTranslation} from "react-i18next";
@@ -7,6 +7,7 @@ import {createBrowserRouter, Navigate, Outlet, RouterProvider, useLocation} from
 import usermgtIcon from "./assets/usermgt_icon_detailed.svg";
 import ProtectedResource from "./components/ProtectedResource";
 import TitledPage from "./components/TitledPage";
+import { ApplicationContext, useApplicationContext } from "./components/contexts/ApplicationContext";
 import {t} from "./helpers/i18nHelpers";
 import {useCasUser} from "./hooks/useCasUser";
 import Account from "./pages/Account";
@@ -20,22 +21,10 @@ import Summaries from "./pages/Summaries";
 import Users from "./pages/Users";
 import UsersImport from "./pages/UsersImport";
 import UsersImportResult from "./pages/UsersImportResult";
-import type {CasUser} from "./services/CasUser";
 
 import "./i18n";
 
 const contextPath = process.env.PUBLIC_URL || "/usermgt";
-
-type ApplicationContextProps = {
-    casUser: CasUser;
-}
-export const ApplicationContext = createContext<ApplicationContextProps>({
-    casUser: {
-        principal: "default",
-        admin: false,
-        loading: true
-    },
-});
 
 const router = createBrowserRouter([
     {
@@ -130,7 +119,7 @@ function ApplicationContainer({children}: ApplicationContainerProps) {
 function Nav() {
     const location = useLocation();
     const {t} = useTranslation();
-    const {casUser} = useContext(ApplicationContext);
+    const {casUser} = useApplicationContext();
     return (
         <>
             <Navbar currentPath={location?.pathname ?? ""}>

--- a/app/src/main/ui/src/pages/EditUser.tsx
+++ b/app/src/main/ui/src/pages/EditUser.tsx
@@ -1,11 +1,11 @@
 import {Button, H1, LoadingIcon} from "@cloudogu/deprecated-ces-theme-tailwind";
-import React, {useContext} from "react";
+import {useContext} from "react";
 import {useNavigate, useParams} from "react-router-dom";
+import { ApplicationContext } from "../components/contexts/ApplicationContext";
 import UserForm from "../components/users/UserForm";
 import {t} from "../helpers/i18nHelpers";
 import {useBackURL} from "../hooks/useBackURL";
 import {useUser} from "../hooks/useUser";
-import {ApplicationContext} from "../main";
 import {UsersService} from "../services/Users";
 import type {User} from "../services/Users";
 

--- a/app/src/main/ui/src/pages/Users.tsx
+++ b/app/src/main/ui/src/pages/Users.tsx
@@ -1,13 +1,13 @@
 import {ActionTable, ActionTableRoot, ConfirmDialog, translate,} from "@cloudogu/ces-theme-tailwind";
 import {Button, H1, Searchbar, useAlertNotification} from "@cloudogu/deprecated-ces-theme-tailwind";
-import React, {useContext, useMemo} from "react";
+import {useContext, useMemo} from "react";
 import {Link, useLocation} from "react-router-dom";
 import {DeleteButton} from "../components/DeleteButton";
 import EditLink from "../components/EditLink";
+import { ApplicationContext } from "../components/contexts/ApplicationContext";
 import {t} from "../helpers/i18nHelpers";
 import {useNotificationAfterRedirect} from "../hooks/useNotificationAfterRedirect";
 import usePaginationTableState from "../hooks/usePaginationTableState";
-import {ApplicationContext} from "../main";
 import {UsersService} from "../services/Users";
 import type {User} from "../services/Users";
 


### PR DESCRIPTION
Additional hints for the creation of users should only be shown to users with admin rights.

ApplicationContext is moved to its own file - imports are adjusted